### PR TITLE
Update offset to be 0 rather than 10 for the root /blog/ page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,7 +95,7 @@ exports.createPages = async ({ actions, graphql }) => {
   await Promise.all(
     chunkedContentNodes.map(async (nodesChunk, i) => {
       const firstNode = nodesChunk[0]
-      const page = i + 1
+      const offset = i ? perPage * page : i
 
       await actions.createPage({
         component: resolve(`./src/templates/index.js`),
@@ -103,7 +103,7 @@ exports.createPages = async ({ actions, graphql }) => {
         context: {
           firstId: firstNode.id,
           page: page,
-          offset: perPage * page,
+          offset: offset,
           totalPages: chunkedContentNodes.length - 1,
           perPage,
         },


### PR DESCRIPTION
The iteration of the map the offset is calculated to be 10. This should be 0. This results in an empty `/blog` page if there are less than 10 blog posts or in proper pagination if there _are_ more than 10.