### PR TITLE
Fix Unique key error

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -31,8 +31,8 @@ export default () => {
             const path = menuItem?.connectedObject?.uri ?? menuItem.url
 
             return (
-              <Link style={{ display: `block` }} to={normalizePath(path)}>
-                <Button w="100%" key={i + menuItem.url} as={Button}>
+              <Link key={i + menuItem.url} style={{ display: `block` }} to={normalizePath(path)}>
+                <Button w="100%" as={Button}>
                   {menuItem.label}
                 </Button>
               </Link>


### PR DESCRIPTION
@TylerBarnes 
First of all . Thank you for the awesome work 👏 

Just a minor thing:
The Link needs to have the key instead of button in menu component

https://github.com/TylerBarnes/using-gatsby-source-wordpress-experimental/blob/bce80b6063ecb60daeebb4c588242f025eadfa86/src/components/menu.js#L35

![image](https://user-images.githubusercontent.com/11497423/80804431-c43dd100-8bd2-11ea-969b-517b2768cc6c.png)

This PR updates the same