### PR TITLE
Bump Gatsby to 2.23.18 to fix  error on build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "add": "^2.0.6",
     "dotenv": "^8.2.0",
     "emotion-theming": "^10.0.27",
-    "gatsby": "2.22.5",
+    "gatsby": "2.23.18",
     "gatsby-image": "^2.4.13",
     "gatsby-plugin-chakra-ui": "^0.1.4",
     "gatsby-plugin-netlify-cache": "^1.2.0",


### PR DESCRIPTION
Hey guys, I set up a new site today using the starter, but kept getting the "Error: Reducers may not dispatch actions." action whenever I tried to build (both locally and on Netlify). This looks to be a version of the issue mentioned here:

https://github.com/gatsbyjs/gatsby/issues/25478

Bumping Gatsby to 2.23.18 fixed this for me, so I'm submitting this in hopes that we can update it—or at least anyone else who runs into the issue might see this! 

Thanks, let me know if you have any questions! 