### PR TITLE
Bumping gatsby version to fix core-js error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "add": "^2.0.6",
     "dotenv": "^8.2.0",
     "emotion-theming": "^10.0.27",
-    "gatsby": "2.24.37",
+    "gatsby": "^2.24.37",
     "gatsby-image": "^2.4.13",
     "gatsby-plugin-chakra-ui": "^0.1.4",
     "gatsby-plugin-netlify-cache": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "add": "^2.0.6",
     "dotenv": "^8.2.0",
     "emotion-theming": "^10.0.27",
-    "gatsby": "2.23.18",
+    "gatsby": "2.24.37",
     "gatsby-image": "^2.4.13",
     "gatsby-plugin-chakra-ui": "^0.1.4",
     "gatsby-plugin-netlify-cache": "^1.2.0",


### PR DESCRIPTION
Hey again! I noticed there seems to be an issue with core-js on gatsby 2.23 (discussed here: https://github.com/gatsbyjs/gatsby/issues/25657), so I'm bumping the version one more time to 2.24.37! Let me know if you have questions, thanks! 