### PR TITLE
fixes "MediaItem.remoteFile is deprecated" error

### DIFF
--- a/src/components/template-parts/blog-post.js
+++ b/src/components/template-parts/blog-post.js
@@ -16,9 +16,9 @@ function BlogPost({ data }) {
         {title}
       </Heading>
 
-      {!!featuredImage?.node?.remoteFile?.childImageSharp && (
+      {!!featuredImage?.node?.localFile?.childImageSharp && (
         <Box mb={5}>
-          <Img fluid={featuredImage.node.remoteFile.childImageSharp.fluid} />
+          <Img fluid={featuredImage.node.localFile.childImageSharp.fluid} />
         </Box>
       )}
 

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -17,10 +17,10 @@ export default ({ data, pageContext }) => (
             <Box p={5} shadow="md" borderWidth="1px">
               <Grid templateColumns="1fr 2fr" gap={6}>
                 <Box>
-                  {!!page?.featuredImage?.node?.remoteFile?.childImageSharp && (
+                  {!!page?.featuredImage?.node?.localFile?.childImageSharp && (
                     <Img
                       fluid={
-                        page.featuredImage.node.remoteFile.childImageSharp.fluid
+                        page.featuredImage.node.localFile.childImageSharp.fluid
                       }
                     />
                   )}
@@ -99,7 +99,7 @@ export const query = graphql`
         title
         featuredImage {
           node {
-            remoteFile {
+            localFile {
               ...Thumbnail
             }
           }

--- a/src/templates/single/Page.js
+++ b/src/templates/single/Page.js
@@ -11,7 +11,7 @@ export const query = graphql`
       content
       featuredImage {
         node {
-          remoteFile {
+          localFile {
             ...HeroImage
           }
         }

--- a/src/templates/single/Post.js
+++ b/src/templates/single/Post.js
@@ -11,7 +11,7 @@ export const query = graphql`
       content
       featuredImage {
         node {
-          remoteFile {
+          localFile {
             ...HeroImage
           }
         }


### PR DESCRIPTION
Fixes this error

There was an error in your GraphQL query:

MediaItem.remoteFile is deprecated and has been renamed to MediaItem.localFile. Please update your code.